### PR TITLE
add charset reader to XML decoder

### DIFF
--- a/feedparser.go
+++ b/feedparser.go
@@ -11,6 +11,9 @@ import (
 	"io"
 	"strings"
 	"time"
+
+	"code.google.com/p/go-charset/charset"
+	_ "code.google.com/p/go-charset/data"
 )
 
 type Feed struct {
@@ -88,6 +91,7 @@ func NewFeed(r io.Reader) (*Feed, error) {
 	feed := &Feed{}
 	item := &FeedItem{}
 	parser := xml.NewDecoder(r)
+	parser.CharsetReader = charset.NewReader
 	for {
 		token, err := parser.Token()
 		if err == io.EOF {


### PR DESCRIPTION
When parsing non-UTF8 feeds the parser returns the following error

```
xml: encoding "ISO-8859-1" declared but Decoder.CharsetReader is nil
```

This PR adds go-charset to solve this problem and allows feedparser to parse non-UTF8 feeds.
